### PR TITLE
fix firefox issues

### DIFF
--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.template.html
@@ -36,7 +36,7 @@
        	   			 <select class="form-control" ng-model="$ctrl.wpsExecuteInputServiceInstance.selectedExecuteInput" 
        	     			ng-options="configuredInput as configuredInput.title for configuredInput in $ctrl.wpsExecuteInputServiceInstance.alreadyConfiguredExecuteInputs" 
        	     			ng-change="$ctrl.onChangeAlreadyDefinedExecuteInput()" required>
-						<option value="" selected hidden>{{
+						<option value="" selected disabled>{{
 							'wpsExecute.inputSetup.alreadyConfiguredInputsPlaceholder' | translate }}</option>
 						<option ng-repeat="configuredInput in $ctrl.wpsExecuteInputServiceInstance.alreadyConfiguredExecuteInputs" ></option>
 					</select>
@@ -88,7 +88,7 @@
 
   					<label>{{'wpsExecute.inputSetup.complexData.selectMimeType' | translate}}</label>
   					<select class="form-control" ng-model="$ctrl.wpsExecuteInputServiceInstance.selectedExecuteInputFormat" ng-options="format as format.mimeType for format in $ctrl.wpsExecuteInputServiceInstance.selectedExecuteInput.complexData.formats" required>
-						<option value="" selected hidden>{{
+						<option value="" selected disabled>{{
 							'wpsExecute.inputSetup.complexData.selectMimeTypePlaceholder' | translate }}</option>
 						<option ng-repeat="format in $ctrl.wpsExecuteInputServiceInstance.selectedExecuteInput.complexData.formats"  ></option>
 					</select>
@@ -151,7 +151,7 @@
   			
   			<label>{{'wpsExecute.inputSetup.boundingBoxData.crs' | translate}}</label>
   			<select class="form-control" ng-model="$ctrl.wpsExecuteInputServiceInstance.selectedExecuteInputCrs"  required>
-				<option value="" selected hidden>{{
+				<option value="" selected disabled>{{
 					'wpsExecute.inputSetup.boundingBoxData.selectCrsPlaceholder' | translate }}</option>
 				<option ng-repeat="crs in $ctrl.wpsExecuteInputServiceInstance.selectedExecuteInput.boundingBoxData.supportedCRSs" >{{crs}}</option>
 			</select>

--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupOutputs/wps-execute-setup-outputs.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupOutputs/wps-execute-setup-outputs.template.html
@@ -36,7 +36,7 @@
        	   			 <select class="form-control" ng-model="$ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutput" 
        	     			ng-options="configuredOutput as configuredOutput.title for configuredOutput in $ctrl.wpsExecuteOutputServiceInstance.alreadyConfiguredExecuteOutputs" 
        	     			ng-change="$ctrl.onChangeAlreadyDefinedExecuteOutput()" required>
-						<option value="" selected hidden>{{
+						<option value="" selected disabled>{{
 							'wpsExecute.outputSetup.alreadyConfiguredOutputsPlaceholder' | translate }}</option>
 						<option ng-repeat="configuredOutput in $ctrl.wpsExecuteOutputServiceInstance.alreadyConfiguredExecuteOutputs" ></option>
 					</select>
@@ -67,7 +67,7 @@
   			<select class="form-control" 
   				ng-model="$ctrl.wpsExecuteOutputServiceInstance.selectedTransmissionMode"
   				 required>
-  				<option value="" selected hidden>{{
+  				<option value="" selected disabled>{{
 							'wpsExecute.outputSetup.selectTransmissionModePlaceholder' | translate }}</option>
 				<option ng-repeat="transmissionMode in $ctrl.wpsPropertiesServiceInstance.processDescription.outputTransmissionModes" >{{transmissionMode}}</option>
 			</select>
@@ -97,7 +97,7 @@
 				<div ng-show="$ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutput.complexData.formats.length > 0">
   					<label>{{'wpsExecute.outputSetup.complexData.selectMimeType' | translate}}</label>
   					<select class="form-control" ng-model="$ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutputFormat" ng-init="$ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutputFormat=$ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutput.complexData.formats[0]" ng-options="format as format.mimeType for format in $ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutput.complexData.formats" required>
-						<option value="" selected hidden>{{
+						<option value="" selected disabled>{{
 							'wpsExecute.outputSetup.complexData.selectMimeTypePlaceholder' | translate }}</option>
 						<option ng-repeat="format in $ctrl.wpsExecuteOutputServiceInstance.selectedExecuteOutput.complexData.formats" ></option>
 					</select>
@@ -119,7 +119,7 @@
   						
   					<label>{{'wpsExecute.outputSetup.transmissionMode' | translate}}</label>
   					<select class="form-control" ng-model="$ctrl.wpsExecuteOutputServiceInstance.selectedTransmissionMode"  required>
-						<option value="" selected hidden>{{
+						<option value="" selected disabled>{{
 							'wpsExecute.outputSetup.selectTransmissionModePlaceholder' | translate }}</option>
 						<option ng-repeat="transmissionMode in $ctrl.wpsPropertiesServiceInstance.processDescription.outputTransmissionModes" >{{transmissionMode}}</option>
 					</select>
@@ -155,7 +155,7 @@
  -->
  			<label>{{'wpsExecute.outputSetup.transmissionMode' | translate}}</label>
 			<select class="form-control" ng-model="$ctrl.wpsExecuteOutputServiceInstance.selectedTransmissionMode"  required>
-				<option value="" selected hidden>{{
+				<option value="" selected disabled>{{
 							'wpsExecute.outputSetup.selectTransmissionModePlaceholder' | translate }}</option>
 				<option ng-repeat="transmissionMode in $ctrl.wpsPropertiesServiceInstance.processDescription.outputTransmissionModes" >{{transmissionMode}}</option>
 			</select>

--- a/app/components/wpsUserInterface/wpsControls/wpsProcesses/wps-processes.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsProcesses/wps-processes.template.html
@@ -13,7 +13,7 @@
 			translate }}</label> <select
 			ng-model="$ctrl.wpsPropertiesServiceInstance.selectedProcess" ng-options="process as process.title for process in $ctrl.wpsPropertiesServiceInstance.capabilities.processes"
 			ng-change="$ctrl.changeWpsProcess()" class="form-control" required>
-			<option value="" selected hidden>{{
+			<option value="" selected disabled>{{
 				'wpsProcesses.selectWpsProcessPlaceholder' | translate }}</option>
 			<option
 				ng-repeat="process in $ctrl.wpsPropertiesServiceInstance.capabilities.processes"></option>

--- a/app/components/wpsUserInterface/wpsControls/wpsSetup/wps-setup.component.js
+++ b/app/components/wpsUserInterface/wpsControls/wpsSetup/wps-setup.component.js
@@ -15,6 +15,7 @@ angular
 								 * references to wpsPropertiesService and wpsFormControl instances
 								 */
 								this.wpsPropertiesServiceInstance = wpsPropertiesService;
+								this.wpsPropertiesServiceInstance.selectedServiceUrl = '';
 								
 								this.wpsFormControlServiceInstance = wpsFormControlService;
 								
@@ -34,7 +35,7 @@ angular
 									wpsFormControlService.disableTabs();
 									wpsFormControlService.resetTabContents();
 									
-									if (this.wpsPropertiesServiceInstance.selectedServiceUrl != 'invalidURL'){
+									if (this.wpsPropertiesServiceInstance.selectedServiceUrl != '' && this.wpsPropertiesServiceInstance.selectedServiceUrl != undefined){
 										wpsPropertiesService.initializeWpsLibrary();
 										wpsPropertiesService.getCapabilities(this.capabilitiesCallback);
 									}

--- a/app/components/wpsUserInterface/wpsControls/wpsSetup/wps-setup.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsSetup/wps-setup.template.html
@@ -14,12 +14,12 @@
 			<div class="form-group">
 				<label for="wps" align="left">{{ 'wpsSetup.chooseWps' |
 					translate }}</label> 
-					<select
+					<select id="wpsSelect"
 					ng-model="$ctrl.wpsPropertiesServiceInstance.selectedServiceUrl"
-					ng-change="$ctrl.changeWpsUrl()" class="form-control" required>
-					<option value="invalidURL" selected hidden>{{
+					ng-options="wpsService for wpsService in $ctrl.wpsPropertiesServiceInstance.availableWpsServices"
+					ng-change="$ctrl.changeWpsUrl()" class="form-control">
+					<option id="testOption" value='' selected disabled>{{
 						'wpsSetup.selectWpsPlaceholder' | translate }}</option>
-					<option ng-repeat="wpsService in $ctrl.wpsPropertiesServiceInstance.availableWpsServices">{{wpsService}}</option>
 				</select>
 				<p></p>
 				<div align="center">

--- a/app/components/wpsUserInterface/wpsControls/wpsSetup/wpsChangeLanguage/wps-change-language.component.js
+++ b/app/components/wpsUserInterface/wpsControls/wpsSetup/wpsChangeLanguage/wps-change-language.component.js
@@ -20,7 +20,7 @@ angular
 						/*
 						 * holds the selected language object
 						 */
-						this.selectedLanguage;
+						this.selectedLanguage = '';
 						
 						this.changeWpsLanguage = function(){
 							$translate.use(this.selectedLanguage.key);

--- a/app/components/wpsUserInterface/wpsControls/wpsSetup/wpsChangeLanguage/wps-change-language.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsSetup/wpsChangeLanguage/wps-change-language.template.html
@@ -5,7 +5,7 @@
 	<select ng-model="$ctrl.selectedLanguage"
 		ng-options="language as language.name for language in $ctrl.availableLanguages"
 		ng-change="$ctrl.changeWpsLanguage()" class="form-control" required>
-		<option value="" selected hidden>{{
+		<option value="" selected disabled>{{
 			'wpsSetup.selectWpsLanguagePlaceholder' | translate }}</option>
 		<option ng-repeat="language in $ctrl.availableLanguages"></option>
 	</select>

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -14,7 +14,7 @@
 		"selectWpsLanguagePlaceholder" : "here you may change the language ...",
 		"addWpsButton": "Add WPS URL",
 		"removeWpsButton": "Remove selected WPS",
-		"chooseWps": "Pleas choose a WPS from the list:",
+		"chooseWps": "Please choose a WPS from the list:",
 		"selectWpsPlaceholder": "select WPS ...",
 		"chooseVersion": "Select the desired WPS service-version",
 		"capabilitiesFailed_short" : "Error",

--- a/app/util/genericServices/wpsService/wps-properties.module.js
+++ b/app/util/genericServices/wpsService/wps-properties.module.js
@@ -30,7 +30,7 @@ angular
 							"http://geostatistics.demo.52north.org/wps/WebProcessingService" ];
 
 					this.serviceVersion = '1.0.0';
-					this.selectedServiceUrl = 'invalidURL';
+					this.selectedServiceUrl = '';
 					
 					this.responseFormats = [ 'document', 'raw' ];
 					
@@ -429,7 +429,7 @@ angular
 							if (this.availableWpsServices[int] == this.selectedServiceUrl) {
 								this.availableWpsServices.splice(int, 1);
 
-								this.selectedServiceUrl = 'invalidURL';
+								this.selectedServiceUrl = '';
 							}
 						}
 					};


### PR DESCRIPTION
now firefox is supported properly. When using select elements, the attribute "hidden" prevented firefox to properly display updated placeholder text values when switching languages.  

now all "hidden" attributes have been replaced by "disabled", which works as expected in all browsers.