### PR TITLE
fixes in Execute Setup of inputs

### DIFF
--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.component.js
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.component.js
@@ -11,17 +11,21 @@ angular
                         'wpsPropertiesService',
                         'wpsFormControlService',
                         'wpsMapService',
+                        'wpsGeometricOutputService',
                         function WpsExecuteSetupInputsController(
                                 $rootScope, $scope,
                                 wpsExecuteInputService,
                                 wpsPropertiesService,
-                                wpsFormControlService, wpsMapService) {
+                                wpsFormControlService, 
+                                wpsMapService, 
+                                wpsGeometricOutputService) {
                             /*
                              * reference to wpsPropertiesService instances
                              */
                             this.wpsExecuteInputServiceInstance = wpsExecuteInputService;
                             this.wpsPropertiesServiceInstance = wpsPropertiesService;
                             this.wpsFormControlServiceInstance = wpsFormControlService;
+                            this.wpsGeometricOutputServiceInstance = wpsGeometricOutputService;
                             this.wpsMapServiceInstance = wpsMapService;
                             
                             // controller layout items;
@@ -157,6 +161,21 @@ angular
                                  * enable removeButton
                                  */
                                 this.wpsFormControlServiceInstance.isRemoveInputButtonDisabled = false;
+                                
+                                /*
+                                 * if it is a GeoJSON input, then extract the geometry and place it on map!
+                                 */
+                                
+                                var inputMimeType = definedInput.mimeType;
+                                
+                                if(wpsGeometricOutputService.isGeoJSON_mimeType(inputMimeType)){
+                                	console.log("GeoJSON geometry will be added to leaflet-draw layer");
+                                	
+                                	var geoJSON_asString = definedInput.complexPayload;
+                                	
+                                	var geoJSON_asObject = JSON.parse(geoJSON_asString);
+                                	$rootScope.$broadcast('add-geometry-to-leaflet-draw-from-geojson-input', {'geoJSON': geoJSON_asObject});
+                                }
                             };
 
 

--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.component.js
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.component.js
@@ -29,7 +29,7 @@ angular
                             this.formData.complexDataInput = "drawing"; // start drawing option by default
                             this.formData.bboxDataInput = "drawing"; // start corners option by default
                             this.mimeTypeSelection = "";
-                            var geoJsonSelected = false;
+                            $scope.geoJsonSelected = false;
 
                             this.onChangeExecuteInput = function (input) {
                                 this.wpsExecuteInputServiceInstance.selectedExecuteInput = input;
@@ -66,7 +66,7 @@ angular
                                 wpsExecuteInputService.asReference = false;
                                 wpsExecuteInputService.complexPayload = undefined;
                                 
-                                geoJsonSelected = false;
+                                $scope.geoJsonSelected = false;
                                 //disable drawing tools
                                 $rootScope.$broadcast('set-complex-data-map-input-enabled', {'enabled': false});
                                 
@@ -179,7 +179,7 @@ angular
                                 this.wpsExecuteInputServiceInstance.selectedExecuteInputFormat = this.getSelectedExecuteInputFormatcomplexInput(complexInput.mimeType, this.wpsExecuteInputServiceInstance.selectedExecuteInput.complexData.formats);
 
                                 if (this.wpsExecuteInputServiceInstance.selectedExecuteInputFormat.mimeType === 'application/vnd.geo+json'){
-                                	geoJsonSelected = true;
+                                	$scope.geoJsonSelected = true;
                                 	$rootScope.$broadcast('set-complex-data-map-input-enabled', {'enabled': true});
                                 }
                                 
@@ -318,12 +318,12 @@ angular
                                 console.log(mimeTypeSelection);
                                 if (mimeTypeSelection === "application/vnd.geo+json") {
                                     console.log("geojson selected.");
-                                    geoJsonSelected = true;
+                                    $scope.geoJsonSelected = true;
                                     this.formData.complexDataInput = "drawing";
                                     $rootScope.$broadcast('set-complex-data-map-input-enabled', {'enabled': true});
                                 } else {
                                     console.log("no geojson selected.");
-                                    geoJsonSelected = false;
+                                    $scope.geoJsonSelected = false;
                                     $rootScope.$broadcast('set-complex-data-map-input-enabled', {'enabled': false});
                                 }
                             };

--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.module.js
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.module.js
@@ -1,1 +1,1 @@
-angular.module('wpsExecuteSetupInputs', ['wpsExecuteInput', 'wpsProperties', 'wpsFormControl']);
+angular.module('wpsExecuteSetupInputs', ['wpsExecuteInput', 'wpsProperties', 'wpsFormControl', 'wpsGeometricOutput']);

--- a/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.template.html
+++ b/app/components/wpsUserInterface/wpsControls/wpsExecute/wpsExecuteSetupRequest/wpsExecuteSetupInputs/wps-execute-setup-inputs.template.html
@@ -95,7 +95,7 @@
 
             <p></p>
 
-            <div class="form-group" ng-if="$ctrl.geoJsonSelected">
+            <div class="form-group" ng-if="geoJsonSelected">
                 <div class="radio">
                     <label>
                         <input type="radio" name="complexDataInput" value="reference" ng-model="$ctrl.formData.complexDataInput" ng-change="$ctrl.complexInputChanged('reference');">
@@ -111,7 +111,8 @@
 
                 <div class="radio">
                     <label>
-                        <input type="radio" name="complexDataInput" value="file" ng-model="$ctrl.formData.complexDataInput" ng-change="$ctrl.complexInputChanged('file');">
+                    <!--  here, the onChange-event is not implemented within controller scope but in the corresponding file!!! -->
+                        TBD not yet implemented! <input type="file" accept=".json" >
                         {{'wpsExecute.inputSetup.complexData.fileUploadInput'| translate}}
                     </label>
                 </div>
@@ -135,7 +136,7 @@
             </div>
             
             <!-- non geojson selection: -->
-            <div ng-if="!$ctrl.geoJsonSelected">
+            <div ng-if="!geoJsonSelected">
                 <div ng-if="$ctrl.wpsExecuteInputServiceInstance.selectedExecuteInputFormat">
                     <div class="checkbox">
                         <label><input type="checkbox" ng-model="$ctrl.wpsExecuteInputServiceInstance.asReference">{{'wpsExecute.inputSetup.complexData.asReference'| translate}}</label>

--- a/app/components/wpsUserInterface/wpsMap/wps-map.component.js
+++ b/app/components/wpsUserInterface/wpsMap/wps-map.component.js
@@ -116,21 +116,44 @@ angular.module('wpsMap').component(
                         $scope.drawnItems.clearLayers();
                         
                     });
-					
-					
-					
+
 					/**
 					 * delete a specific overlay for specific input identifier
 					 */
-					$scope.$on('delete-overlay-for-input', function (event, args) {
-                        console.log("delete-overlay-for-input has been called.");
+					$scope.$on('add-geometry-to-leaflet-draw-from-geojson-input', function (event, args) {
+                        console.log("add-geometry-to-leaflet-draw-from-geojson-input has been called.");
                         console.log(args);
 
-                        var inputIdentifier = args.inputIdentifier;
+                        var geoJSON_asObject = args.geoJSON;
                         
-                        var layerPropertyName = wpsMapService.generateUniqueInputLayerPropertyName(inputIdentifier);
+                        L.geoJson(geoJSON_asObject, {
+                        	  onEachFeature: function (feature, layer) {
+                        	    if (layer.getLayers) {
+                        	      layer.getLayers().forEach(function (currentLayer) {
+                        	        $scope.drawnItems.addLayer(currentLayer);
+                        	      })
+                        	    } else {
+                        	    	$scope.drawnItems.addLayer(layer);
+                        	    }
+                        	  },
+                        	  style: {
+                                  color: '#f06eaa',
+                                  fillColor: null,
+                                  weight: 4.0,
+                                  opacity: 0.5,
+                                  fillOpacity: 0.2
+                        	  }
+                        	});
                         
-                        delete $scope.layers.overlays[layerPropertyName];
+                    });
+					
+					/**
+					 * clear all layers of leaflet-draw layer
+					 */
+					$scope.$on('clear-draw-layers', function (event, args) {
+                        console.log("clear-draw-layers has been called.");
+
+                        $scope.drawnItems.clearLayers();
                         
                     });
                     

--- a/app/components/wpsUserInterface/wpsMap/wps-map.component.js
+++ b/app/components/wpsUserInterface/wpsMap/wps-map.component.js
@@ -98,6 +98,22 @@ angular.module('wpsMap').component(
 					};
 					
 					/**
+					 * delete overlay for given input identifier
+					 */
+					$scope.$on('delete-overlay-for-input', function (event, args) {
+                        console.log("delete-overlay-for-input has been called.");
+                        
+                        var inputIdentifier = args.inputIdentifier;
+                        
+                        var inputLayerPropertyName = wpsMapService.generateUniqueInputLayerPropertyName(inputIdentifier)
+
+                        delete $scope.layers.overlays[inputLayerPropertyName];
+                        
+                        console.log($scope.layers.overlays);
+                        
+                    });
+					
+					/**
 					 * remove all overlays from map
 					 */
 					$scope.$on('reset-map-overlays', function (event, args) {

--- a/app/util/genericServices/wpsGeometricOutputService/wps-geometric-output.module.js
+++ b/app/util/genericServices/wpsGeometricOutputService/wps-geometric-output.module.js
@@ -189,8 +189,18 @@ angular.module('wpsGeometricOutput').service('wpsGeometricOutputService',
 					format = currentOutput.data.complexData.mimeType;
 				}
 				
-				if (format === 'application/vnd.geo+json')
+				if (this.isGeoJSON_mimeType(format))
 					return true;
+				
+				return false;
+			};
+			
+			this.isGeoJSON_mimeType = function(mimeType){
+				
+				if (mimeType === 'application/vnd.geo+json')
+					return true;
+				
+				return false;
 			};
 			
 			this.isWMS = function(currentOutput){


### PR DESCRIPTION
- proper display of all choosable options for GeoJSON inputs
- when an already defined GeoJSON Execute input is re-selected, then it's geometry is fetched and added to leaflet-draw layer for easy modification
- when removing an already defined Execute input, then the associated Lealfet overlays layer is removed as well